### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ WaveDrawable
 
 Drawable animation inspired by Tinder.
 
-###Download
+### Download
 ```Groovy
 compile 'me.alexrs:wave-drawable:1.0.0'
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
